### PR TITLE
implement lazy initialization.

### DIFF
--- a/dagstore_async.go
+++ b/dagstore_async.go
@@ -52,9 +52,9 @@ func (d *DAGStore) acquireAsync(ctx context.Context, w *waiter, s *Shard, mnt mo
 	d.sendResult(&ShardResult{Key: k, Accessor: sa, Error: err}, w)
 }
 
-// initializeAsync initializes a shard asynchronously by fetching its data and
+// indexShard initializes a shard asynchronously by fetching its data and
 // performing indexing.
-func (d *DAGStore) initializeAsync(ctx context.Context, s *Shard, mnt mount.Mount) {
+func (d *DAGStore) indexShard(ctx context.Context, w *waiter, s *Shard, mnt mount.Mount) {
 	reader, err := mnt.Fetch(ctx)
 	if err != nil {
 		_ = d.failShard(s, d.completionCh, "failed to acquire reader of mount: %w", err)
@@ -78,5 +78,5 @@ func (d *DAGStore) initializeAsync(ctx context.Context, s *Shard, mnt mount.Moun
 		return
 	}
 
-	_ = d.queueTask(&task{op: OpShardMakeAvailable, shard: s}, d.completionCh)
+	_ = d.queueTask(&task{op: OpShardMakeAvailable, shard: s, waiter: w}, d.completionCh)
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -17,6 +17,10 @@ func (d *DAGStore) dispatcher() {
 
 func (d *DAGStore) sendResult(res *ShardResult, waiters ...*waiter) {
 	for _, w := range waiters {
+		if w.outCh == nil {
+			// no return channel; skip.
+			continue
+		}
 		d.dispatchCh <- &dispatch{w: w, res: res}
 	}
 }

--- a/mount/counting.go
+++ b/mount/counting.go
@@ -1,0 +1,23 @@
+package mount
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// Counting is a mount that proxies to another mount and counts the number of
+// calls made to Fetch. It is mostly used in tests.
+type Counting struct {
+	Mount
+
+	n int32
+}
+
+func (c *Counting) Fetch(ctx context.Context) (Reader, error) {
+	atomic.AddInt32(&c.n, 1)
+	return c.Mount.Fetch(ctx)
+}
+
+func (c *Counting) Count() int {
+	return int(atomic.LoadInt32(&c.n))
+}

--- a/mount/upgrader_test.go
+++ b/mount/upgrader_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/filecoin-project/dagstore/testdata"
@@ -134,31 +133,9 @@ func TestUpgrade(t *testing.T) {
 	}
 }
 
-type countingMount struct {
-	mu sync.Mutex
-	n  int
-
-	Mount
-}
-
-func (c *countingMount) Fetch(ctx context.Context) (Reader, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.n++
-
-	return c.Mount.Fetch(ctx)
-}
-
-func (c *countingMount) Count() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.n
-}
-
 func TestUpgraderDeduplicatesRemote(t *testing.T) {
 	ctx := context.Background()
-	mnt := &countingMount{Mount: &FSMount{testdata.FS, testdata.FSPathCarV2}}
+	mnt := &Counting{Mount: &FSMount{testdata.FS, testdata.FSPathCarV2}}
 
 	key := fmt.Sprintf("%d", rand.Uint64())
 	rootDir := t.TempDir()

--- a/shard.go
+++ b/shard.go
@@ -31,6 +31,7 @@ type Shard struct {
 	d     *DAGStore       // backreference
 	key   shard.Key       // persisted in PersistedShard.Key
 	mount *mount.Upgrader // persisted in PersistedShard.URL (underlying)
+	lazy  bool            // persisted in PersistedShard.Lazy; whether this shard has lazy indexing
 
 	// Mutable fields.
 	// Cannot read/write outside event loop.

--- a/shard_persist.go
+++ b/shard_persist.go
@@ -16,6 +16,7 @@ type PersistedShard struct {
 	Key   string     `json:"k"`
 	URL   string     `json:"u"`
 	State ShardState `json:"s"`
+	Lazy  bool       `json:"l"`
 	Error string     `json:"e"`
 }
 
@@ -31,6 +32,7 @@ func (s *Shard) MarshalJSON() ([]byte, error) {
 		Key:   s.key.String(),
 		URL:   u.String(),
 		State: s.state,
+		Lazy:  s.lazy,
 	}
 	if s.err != nil {
 		ps.Error = s.err.Error()
@@ -54,6 +56,7 @@ func (s *Shard) UnmarshalJSON(b []byte) error {
 	// restore basics.
 	s.key = shard.KeyFromString(ps.Key)
 	s.state = ps.State
+	s.lazy = ps.Lazy
 	if ps.Error != "" {
 		s.err = errors.New(ps.Error)
 	}


### PR DESCRIPTION
Closes #45.

This PR implements lazy initialization. When registering a shard, users can now pass an option:

```go
err := dagst.RegisterShard(context.Background(), k, mount, ch, RegisterOpts{
		LazyInitialization: true,
})
```

If `true`, the shard will not be fetched and indexed until its first acquire. The registration callback channel will fire immediately after the control loop has acknowleged the registration.

To support this option, the fetching/indexing logic has been separated out into an `OpShardInitialize` operation.

Lazy init is saved as an attribute in the persistent shard representation, and recovered when restarting.