### PR TITLE
Ignore nil channels in the dispatcher

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -16,6 +16,9 @@ type waiter struct {
 }
 
 func (w waiter) deliver(res *ShardResult) {
+	if w.outCh == nil {
+		return
+	}
 	select {
 	case w.outCh <- *res:
 	case <-w.ctx.Done():


### PR DESCRIPTION
If the code directly writes to the channel that the `dispatcher` function is reading from, we could escape the nil channel check we've put in place in the `dispatchResult` function.