### PR TITLE
Enable `UseWholeCIDs` since by default CARv2 uses multihash

### DIFF
--- a/accessor.go
+++ b/accessor.go
@@ -70,7 +70,7 @@ func (sa *ShardAccessor) Blockstore() (ReadBlockstore, error) {
 	}
 	sa.lk.Unlock()
 
-	bs, err := blockstore.NewReadOnly(r, sa.idx, carv2.ZeroLengthSectionAsEOF(true))
+	bs, err := blockstore.NewReadOnly(r, sa.idx, carv2.ZeroLengthSectionAsEOF(true), blockstore.UseWholeCIDs(true))
 	return bs, err
 }
 


### PR DESCRIPTION
Explicitly set the option `UseWholeCIDs` to ture, since v2 uses
multihash by default.