### PR TITLE
acquire when errored: fix result being dispatched on wrong waiter.

### DIFF
--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -132,11 +132,10 @@ func (d *DAGStore) control() {
 			w := &waiter{ctx: tsk.ctx, outCh: tsk.outCh}
 
 			// if the shard is errored, fail the acquire immediately.
-			// TODO needs test
 			if s.state == ShardStateErrored {
 				err := fmt.Errorf("shard is in errored state; err: %w", s.err)
 				res := &ShardResult{Key: s.key, Error: err}
-				d.dispatchResult(res, s.wRegister)
+				d.dispatchResult(res, w)
 				break
 			}
 

--- a/dagstore_test.go
+++ b/dagstore_test.go
@@ -627,7 +627,7 @@ func TestIndexingFailure(t *testing.T) {
 			require.EqualValues(t, ShardStateErrored, evt.After.ShardState)
 			require.Error(t, evt.After.Error)
 		default:
-			require.Fail(t, "unexpected op: %s", evt.Op)
+			t.Fatalf("unexpected op: %s", evt.Op)
 		}
 	}
 
@@ -665,13 +665,24 @@ func TestIndexingFailure(t *testing.T) {
 			require.False(t, istat.Exists)
 		}
 
-		evts := make([]Trace, 32)
+		// verify that all acquires fail immediately.
+		for k := range dagst.AllShardsInfo() {
+			ch := make(chan ShardResult)
+			err := dagst.AcquireShard(context.Background(), k, ch, AcquireOpts{})
+			require.NoError(t, err)
+			res := <-ch
+			require.Error(t, res.Error)
+			require.Equal(t, k, res.Key)
+			require.Nil(t, res.Accessor)
+		}
+
+		evts := make([]Trace, 48)
 		n, timedOut := sink.Read(evts, 50*time.Millisecond)
 		require.False(t, timedOut)
-		require.Equal(t, 32, n)
+		require.Equal(t, 48, n)
 
-		// these 32 traces are OpShardRecover, OpShardFail.
-		for i := 0; i < 32; i++ {
+		// these 48 traces are OpShardRecover, OpShardFail, OpShardAcquire.
+		for i := 0; i < 48; i++ {
 			evt := evts[i]
 			switch evt.Op {
 			case OpShardRecover:
@@ -680,8 +691,11 @@ func TestIndexingFailure(t *testing.T) {
 			case OpShardFail:
 				require.EqualValues(t, ShardStateErrored, evt.After.ShardState)
 				require.Error(t, evt.After.Error)
+			case OpShardAcquire:
+				require.EqualValues(t, ShardStateErrored, evt.After.ShardState)
+				require.Error(t, evt.After.Error)
 			default:
-				require.Fail(t, "unexpected op: %s", evt.Op)
+				t.Fatalf("unexpected op: %s", evt.Op)
 			}
 		}
 
@@ -721,13 +735,25 @@ func TestIndexingFailure(t *testing.T) {
 			require.True(t, istat.Exists)
 		}
 
-		evts := make([]Trace, 32)
+		// verify that all acquires succeed now.
+		for k := range dagst.AllShardsInfo() {
+			ch := make(chan ShardResult)
+			err := dagst.AcquireShard(context.Background(), k, ch, AcquireOpts{})
+			require.NoError(t, err)
+
+			res := <-ch
+			require.NoError(t, res.Error)
+			require.Equal(t, k, res.Key)
+			require.NotNil(t, res.Accessor)
+		}
+
+		evts := make([]Trace, 48)
 		n, timedOut := sink.Read(evts, 50*time.Millisecond)
 		require.False(t, timedOut)
-		require.Equal(t, 32, n)
+		require.Equal(t, 48, n)
 
-		// these 32 traces are OpShardRecover, OpShardFail.
-		for i := 0; i < 32; i++ {
+		// these 48 traces are OpShardRecover, OpShardFail.
+		for i := 0; i < 48; i++ {
 			evt := evts[i]
 			switch evt.Op {
 			case OpShardRecover:
@@ -736,13 +762,15 @@ func TestIndexingFailure(t *testing.T) {
 			case OpShardMakeAvailable:
 				require.EqualValues(t, ShardStateAvailable, evt.After.ShardState)
 				require.NoError(t, evt.After.Error)
+			case OpShardAcquire:
+				require.EqualValues(t, ShardStateServing, evt.After.ShardState)
+				require.NoError(t, evt.After.Error)
 			default:
-				require.Fail(t, "unexpected op: %s", evt.Op)
+				t.Fatalf("unexpected op: %s", evt.Op)
 			}
 		}
 
 	})
-
 }
 
 // TestBlockCallback tests that blocking a callback blocks the dispatcher


### PR DESCRIPTION
Also adds test coverage for this branch.