### PR TITLE
add a failure handler utility to recover shards immediately.

### DIFF
--- a/dagstore_test.go
+++ b/dagstore_test.go
@@ -740,8 +740,55 @@ func TestIndexingFailure(t *testing.T) {
 				require.Fail(t, "unexpected op: %s", evt.Op)
 			}
 		}
-
 	})
+}
+
+func TestFailureRecovery(t *testing.T) {
+	r := testRegistry(t)
+	dir := t.TempDir()
+	sink := tracer(128)
+	failures := make(chan ShardResult, 128)
+	dagst, err := NewDAGStore(Config{
+		MountRegistry: r,
+		TransientsDir: dir,
+		TraceCh:       sink,
+		FailureCh:     failures,
+	})
+	go RecoverImmediately(context.Background(), dagst, failures, 10) // 10 max attempts.
+	require.NoError(t, err)
+
+	// register 16 shards with junk in them, so they will fail indexing.
+	resCh := make(chan ShardResult, 16)
+	junkmnt := *junkmnt // take a copy
+	for i := 0; i < 16; i++ {
+		k := shard.KeyFromString(strconv.Itoa(i))
+		err := dagst.RegisterShard(context.Background(), k, &junkmnt, resCh, RegisterOpts{})
+		require.NoError(t, err)
+	}
+
+	evts := make([]Trace, 368)
+	n, timedOut := sink.Read(evts, 5*time.Second)
+	require.False(t, timedOut)
+	require.Equal(t, 368, n)
+
+	counts := map[OpType]int{}
+	for _, evt := range evts {
+		counts[evt.Op]++
+
+		switch evt.Op {
+		case OpShardRecover:
+			require.EqualValues(t, ShardStateRecovering, evt.After.ShardState)
+			require.Error(t, evt.After.Error)
+		case OpShardFail:
+			require.EqualValues(t, ShardStateErrored, evt.After.ShardState)
+			require.Error(t, evt.After.Error)
+		}
+	}
+
+	require.Equal(t, counts[OpShardRegister], 16)
+	require.Equal(t, counts[OpShardInitialize], 16)
+	require.Equal(t, counts[OpShardFail], 176)
+	require.Equal(t, counts[OpShardRecover], 160)
 
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -11,7 +11,9 @@ import (
 // unique shard.
 //
 // Attempt tracking does not survive restarts. When the passed context fires,
-// the failure handler goroutine will yield
+// the failure handler will yield. It is recommended to call this
+// method from a dedicated goroutine, as it runs an infinite event
+// loop.
 func RecoverImmediately(ctx context.Context, dagst *DAGStore, failureCh chan ShardResult, maxAttempts uint64) {
 	var (
 		recResCh = make(chan ShardResult, 128)

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,59 @@
+package dagstore
+
+import (
+	"context"
+
+	"github.com/filecoin-project/dagstore/shard"
+)
+
+// RecoverImmediately takes a failureCh were DAGStore failures are sent, and
+// attempts to recover the shard immediately up until maxAttempts for each
+// unique shard.
+//
+// Attempt tracking does not survive restarts. When the passed context fires,
+// the failure handler goroutine will yield
+func RecoverImmediately(ctx context.Context, dagst *DAGStore, failureCh chan ShardResult, maxAttempts uint64) {
+	var (
+		recResCh = make(chan ShardResult, 128)
+		attempts = make(map[shard.Key]uint64)
+	)
+
+	for {
+		select {
+		case res := <-failureCh:
+			key := res.Key
+			att := attempts[key]
+			if att >= maxAttempts {
+				log.Infow("failure handler: max attempts exceeded; skipping recovery", "key", key, "from_error", res.Error, "attempt", att)
+				continue
+			}
+
+			log.Infow("failure handler: recovering shard", "key", key, "from_error", res.Error, "attempt", att)
+
+			// queue the recovery for this key.
+			if err := dagst.RecoverShard(ctx, key, recResCh, RecoverOpts{}); err != nil {
+				log.Warnw("failure handler: failed to queue shard recovery", "key", key, "error", err)
+				continue
+			}
+			attempts[key]++
+
+		case res := <-recResCh:
+			// this channel is just informational; a failure to recover will
+			// trigger another failure on the failureCh, which will be handled
+			// above for retry.
+			key := res.Key
+			if res.Error == nil {
+				log.Infow("failure handler: successfully recovered shard", "key", key)
+				delete(attempts, key)
+			} else {
+				log.Warnw("failure handler: failed to recover shard", "key", key, "attempt", attempts[key])
+			}
+			continue
+
+		case <-ctx.Done():
+			log.Info("failure handler: stopping")
+			attempts = nil
+			return
+		}
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filecoin-project/dagstore/shard"
 )
 
-// RecoverImmediately takes a failureCh were DAGStore failures are sent, and
+// RecoverImmediately takes a failureCh where DAGStore failures are sent, and
 // attempts to recover the shard immediately up until maxAttempts for each
 // unique shard.
 //


### PR DESCRIPTION
This introduces a utility that DAG Store users can rely on to recover shard failures automatically, up to a maximum number of attempts. It currently does not support backoff; see #79.