### PR TITLE
Bug Fixes and logging

### DIFF
--- a/dagstore_async.go
+++ b/dagstore_async.go
@@ -30,7 +30,7 @@ func (d *DAGStore) acquireAsync(ctx context.Context, w *waiter, s *Shard, mnt mo
 		_ = d.queueTask(&task{op: OpShardRelease, shard: s}, d.completionCh)
 
 		// fail the shard
-		_ = d.failShard(s, d.completionCh, "failed to acquire reader of mount: %w", err)
+		_ = d.failShard(s, d.completionCh, "failed to acquire reader of mount so we can return the accessor: %w", err)
 
 		// send the shard error to the caller.
 		d.dispatchResult(&ShardResult{Key: k, Error: err}, w)
@@ -71,7 +71,7 @@ func (d *DAGStore) initializeShard(ctx context.Context, s *Shard, mnt mount.Moun
 	})
 
 	if err != nil {
-		_ = d.failShard(s, d.completionCh, "failed to acquire reader of mount: %w", err)
+		_ = d.failShard(s, d.completionCh, "failed to acquire reader of mount so that we can initialize the shard: %w", err)
 		return
 	}
 	defer reader.Close()

--- a/dagstore_test.go
+++ b/dagstore_test.go
@@ -784,7 +784,7 @@ func TestFailureRecovery(t *testing.T) {
 		FailureCh:     failures,
 	})
 
-	go RecoverImmediately(context.Background(), dagst, failures, 10) // 10 max attempts.
+	go RecoverImmediately(context.Background(), dagst, failures, 10, nil) // 10 max attempts.
 	require.NoError(t, err)
 
 	// register 16 shards with junk in them, so they will fail indexing.

--- a/handlers.go
+++ b/handlers.go
@@ -11,10 +11,13 @@ import (
 // unique shard.
 //
 // Attempt tracking does not survive restarts. When the passed context fires,
-// the failure handler will yield. It is recommended to call this
+// the failure handler will yield and the given `onDone` function is called before returning. It is recommended to call this
 // method from a dedicated goroutine, as it runs an infinite event
 // loop.
-func RecoverImmediately(ctx context.Context, dagst *DAGStore, failureCh chan ShardResult, maxAttempts uint64) {
+func RecoverImmediately(ctx context.Context, dagst *DAGStore, failureCh chan ShardResult, maxAttempts uint64, onDone func()) {
+	if onDone != nil {
+		defer onDone()
+	}
 	var (
 		recResCh = make(chan ShardResult, 128)
 		attempts = make(map[shard.Key]uint64)


### PR DESCRIPTION
Closes #80 .

- If we persist a shard in errored state to the datastore and then crash and restart, the shard would have forever stayed in the errored state.

- Shard Recovery should respect lazy initialization.

- Document that clients have to always actively consume from the trace and failure channels.

- Logging for all the Upgrader magic. Logging for everything.

### TODO
- [x] GoDocs.
- [x] Solid Unit tests for the changes introduced here.