### PR TITLE
review #81

### DIFF
--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -126,7 +126,6 @@ func (d *DAGStore) control() {
 				// optimistically increment the refcount to acquire the shard. The go-routine will send an `OpShardRelease` message
 				// to the event loop if it fails to acquire the shard.
 				s.refs++
-				// TODO Can we pass in  a looping pointer variable as is to a go-routine ?
 				go d.acquireAsync(w.ctx, w, s, s.mount)
 			}
 			s.wAcquire = s.wAcquire[:0]

--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -137,9 +137,21 @@ func (d *DAGStore) control() {
 
 			// if the shard is errored, fail the acquire immediately.
 			if s.state == ShardStateErrored {
-				err := fmt.Errorf("shard is in errored state; err: %w", s.err)
-				res := &ShardResult{Key: s.key, Error: err}
-				d.dispatchResult(res, w)
+				if s.recoverOnNextAcquire {
+					// we are errored, but recovery was requested on the next acquire
+					// we park the acquirer and trigger a recover.
+					s.wAcquire = append(s.wAcquire, w)
+					s.recoverOnNextAcquire = false
+					// we use the global context instead of the acquire context
+					// to avoid the first context cancellation interrupting the
+					// recovery that may be blocking other acquirers with longer
+					// contexts.
+					_ = d.queueTask(&task{op: OpShardRecover, shard: s, waiter: &waiter{ctx: d.ctx}}, d.internalCh)
+				} else {
+					err := fmt.Errorf("shard is in errored state; err: %w", s.err)
+					res := &ShardResult{Key: s.key, Error: err}
+					d.dispatchResult(res, w)
+				}
 				break
 			}
 
@@ -269,17 +281,6 @@ func (d *DAGStore) control() {
 				log.Warnw("recovery: failed to drop index for shard", "shard", s.key, "error", err)
 			} else if !dropped {
 				log.Debugw("recovery: no index dropped for shard", "shard", s.key)
-			}
-
-			if s.lazy {
-				log.Debugw("shard recovered with lazy initialization, resetting shard state to ShardStateNew", "shard", s.key)
-				// waiter will be nil if this was a restart and not a call to RecoverShard().
-				if tsk.waiter != nil {
-					res := &ShardResult{Key: s.key}
-					d.dispatchResult(res, tsk.waiter)
-				}
-				s.state = ShardStateNew
-				break
 			}
 
 			// fetch again and reindex.

--- a/mount/upgrader.go
+++ b/mount/upgrader.go
@@ -12,7 +12,7 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-var log = logging.Logger("dagstore-upgrader")
+var log = logging.Logger("dagstore/upgrader")
 
 // Upgrader is a bridge to upgrade any Mount into one with full-featured
 // Reader capabilities, whether the original mount is of remote or local kind.
@@ -52,7 +52,7 @@ func Upgrade(underlying Mount, rootdir, key string, initial string) (*Upgrader, 
 
 	if initial != "" {
 		if _, err := os.Stat(initial); err == nil {
-			log.Debugw("upgrader initialized with existing transient that's alive", "shard", key, "transient", initial)
+			log.Debugw("initialized with existing transient that's alive", "shard", key, "path", initial)
 			ret.transient = initial
 			return ret, nil
 		}
@@ -63,7 +63,7 @@ func Upgrade(underlying Mount, rootdir, key string, initial string) (*Upgrader, 
 
 func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 	if u.passthrough {
-		log.Debugw("mount has all capabilities, fetching from the underlying mount", "shard", u.key)
+		log.Debugw("fully capable mount; fetching from underlying", "shard", u.key)
 		return u.underlying.Fetch(ctx)
 	}
 
@@ -72,13 +72,13 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 	// after it's done, open the resulting transient.
 	u.lk.Lock()
 	if u.transient != "" {
-		log.Debugw("have an existing transient copy, checking if we can use it for the fetch", "shard", u.key, "transient", u.transient)
+		log.Debugw("transient copy exists; check liveness", "shard", u.key, "path", u.transient)
 		if _, err := os.Stat(u.transient); err == nil {
-			log.Debugw("transient is still alive, not refetching", "shard", u.key, "transient", u.transient)
+			log.Debugw("transient copy alive; not refetching", "shard", u.key, "path", u.transient)
 			defer u.lk.Unlock()
 			return os.Open(u.transient)
 		} else {
-			log.Debugw("existing transient copy not usable, will refetch", "shard", u.key, "transient", u.transient, "error", err)
+			log.Debugw("transient copy dead; refetching", "shard", u.key, "path", u.transient, "error", err)
 		}
 		// TODO add size check.
 	}
@@ -91,7 +91,7 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 	once.Do(func() {
 		err = u.refetch(ctx)
 		if err != nil {
-			log.Errorw("failed to refetch transient", "shard", u.key, "error", err)
+			log.Errorw("failed to refetch", "shard", u.key, "error", err)
 		}
 	})
 
@@ -102,7 +102,7 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 	u.lk.Lock()
 	defer u.lk.Unlock()
 
-	log.Debugw("finished refetching transient", "shard", u.key, "transient", u.transient)
+	log.Debugw("refetched successfully", "shard", u.key, "path", u.transient)
 	return os.Open(u.transient)
 }
 
@@ -147,10 +147,10 @@ func (u *Upgrader) Close() error {
 }
 
 func (u *Upgrader) refetch(ctx context.Context) error {
-	log.Debugw("will refetch transient", "shard", u.key, "transient", u.transient)
+	log.Debugw("actually refetching", "shard", u.key, "dead_path", u.transient)
 	u.lk.Lock()
 	if u.transient != "" {
-		log.Debugw("removing transient", "shard", u.key, "transient", u.transient)
+		log.Debugw("removing dead transient", "shard", u.key, "dead_path", u.transient)
 		_ = os.Remove(u.transient)
 	}
 	u.lk.Unlock()
@@ -183,7 +183,7 @@ func (u *Upgrader) refetch(ctx context.Context) error {
 	// set the new transient path under a lock, and recycle the sync.Once.
 	u.lk.Lock()
 	u.transient = file.Name()
-	log.Debugw("updated transient path after refetching", "shard", u.key, "transient", u.transient)
+	log.Debugw("transient path updated after refetching", "shard", u.key, "new_path", u.transient)
 	u.once = new(sync.Once)
 	u.lk.Unlock()
 
@@ -199,14 +199,14 @@ func (u *Upgrader) DeleteTransient() error {
 	defer u.lk.Unlock()
 
 	if u.transient == "" {
-		log.Debugw("transient is empty, nothing to remove", "shard", u.key)
+		log.Debugw("transient is empty; nothing to remove", "shard", u.key)
 		return nil // nothing to do.
 	}
 
 	// refuse to delete the transient if it's not being managed by us (i.e. in
 	// our transients root directory).
 	if _, err := filepath.Rel(u.rootdir, u.transient); err != nil {
-		log.Debugw("transient is not owned by us, nothing to remove", "shard", u.key)
+		log.Debugw("transient is not owned by us; nothing to remove", "shard", u.key)
 		return nil
 	}
 
@@ -215,6 +215,6 @@ func (u *Upgrader) DeleteTransient() error {
 	// deleting the transient we're currently tracking.
 	err := os.Remove(u.transient)
 	u.transient = ""
-	log.Debugw("deleted existing transient", "shard", u.key, "transient", u.transient, "error", err)
+	log.Debugw("deleted existing transient", "shard", u.key, "path", u.transient, "error", err)
 	return err
 }

--- a/mount/upgrader.go
+++ b/mount/upgrader.go
@@ -142,8 +142,10 @@ func (u *Upgrader) Deserialize(url *url.URL) error {
 	return u.underlying.Deserialize(url)
 }
 
+// TODO implement
 func (u *Upgrader) Close() error {
-	panic("implement me")
+	log.Warnf("Upgrader.Close() not implemented yet; call will no-op")
+	return nil
 }
 
 func (u *Upgrader) refetch(ctx context.Context) error {

--- a/shard.go
+++ b/shard.go
@@ -41,6 +41,8 @@ type Shard struct {
 	state ShardState // persisted in PersistedShard.State
 	err   error      // persisted in PersistedShard.Error; populated if shard state is errored.
 
+	recoverOnNextAcquire bool // a shard marked in error state during initialization can be recovered on its first acquire.
+
 	// Waiters.
 	wRegister *waiter   // waiter for registration result.
 	wRecover  *waiter   // waiter for recovering an errored shard.


### PR DESCRIPTION
One commit per change.

This mainly redesigns the "recovery on start" solution introduced in #81, and also adds a comprehensive test.

The `RecoverOnStartPolicy` enum values have been renamed to describe the behaviour more accurately.

We no longer piggyback on the `lazy` flag, which is only relevant during registration/initialization. We introduce a `recoverOnFirstAcquire` flag instead of overloading `lazy`.

Finally, I've polished log statements, implemented an unimplemented method to avoid panicking, and made additional fixes to the upgrader.