### PR TITLE
persist transient path + add tests.

### DIFF
--- a/index/repo.go
+++ b/index/repo.go
@@ -11,7 +11,7 @@ var ErrNotFound = errors.New("index not found")
 
 // Repo is the central index repository object that manages full indices and
 // manifests.
-type Repo struct {
+type Repo interface {
 	FullIndexRepo
 	ManifestRepo
 }

--- a/index/repo_fs.go
+++ b/index/repo_fs.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +30,7 @@ var _ FullIndexRepo = (*FSIndexRepo)(nil)
 func NewFSRepo(baseDir string) (*FSIndexRepo, error) {
 	err := os.MkdirAll(baseDir, os.ModePerm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create index repo dir: %w", err)
 	}
 
 	l := &FSIndexRepo{baseDir: baseDir}

--- a/shard_persist.go
+++ b/shard_persist.go
@@ -13,11 +13,12 @@ import (
 
 // PersistedShard is the persistent representation of the Shard.
 type PersistedShard struct {
-	Key   string     `json:"k"`
-	URL   string     `json:"u"`
-	State ShardState `json:"s"`
-	Lazy  bool       `json:"l"`
-	Error string     `json:"e"`
+	Key           string     `json:"k"`
+	URL           string     `json:"u"`
+	TransientPath string     `json:"t"`
+	State         ShardState `json:"s"`
+	Lazy          bool       `json:"l"`
+	Error         string     `json:"e"`
 }
 
 // MarshalJSON returns a serialized representation of the state. It must be
@@ -29,10 +30,11 @@ func (s *Shard) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode mount: %w", err)
 	}
 	ps := PersistedShard{
-		Key:   s.key.String(),
-		URL:   u.String(),
-		State: s.state,
-		Lazy:  s.lazy,
+		Key:           s.key.String(),
+		URL:           u.String(),
+		State:         s.state,
+		Lazy:          s.lazy,
+		TransientPath: s.mount.TransientPath(),
 	}
 	if s.err != nil {
 		ps.Error = s.err.Error()
@@ -70,7 +72,7 @@ func (s *Shard) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to instantiate mount from URL: %w", err)
 	}
-	s.mount, err = mount.Upgrade(mnt, s.d.config.TransientsDir, s.key.String(), "")
+	s.mount, err = mount.Upgrade(mnt, s.d.config.TransientsDir, s.key.String(), ps.TransientPath)
 	if err != nil {
 		return fmt.Errorf("failed to apply mount upgrader: %w", err)
 	}


### PR DESCRIPTION
Fixes #85, and adds two tests. One relevant to this fix, one that tests that we correctly handle missing indices on acquire (related to #83).