### PR TITLE
refactor GC and implement reconciliation.

### DIFF
--- a/dagstore.go
+++ b/dagstore.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/dagstore/index"
 	"github.com/filecoin-project/dagstore/mount"
 	"github.com/filecoin-project/dagstore/shard"
-	"github.com/hashicorp/go-multierror"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-datastore/query"
@@ -86,6 +85,8 @@ type DAGStore struct {
 	// back to the application. Serviced by a dispatcher goroutine.
 	// See note in dispatchResultsCh for background.
 	dispatchFailuresCh chan *dispatch
+	// gcCh is where requests for GC are sent.
+	gcCh chan chan *GCResult
 
 	// Channels not owned by us.
 	//
@@ -210,6 +211,7 @@ func NewDAGStore(cfg Config) (*DAGStore, error) {
 		internalCh:        make(chan *task, 1),       // len=1, because eventloop will only ever stage another internal event.
 		completionCh:      make(chan *task, 64),      // len=64, hitting this limit will just make async tasks wait.
 		dispatchResultsCh: make(chan *dispatch, 128), // len=128, same as externalCh.
+		gcCh:              make(chan chan *GCResult, 8),
 		traceCh:           cfg.TraceCh,
 		failureCh:         cfg.FailureCh,
 		throttleFetch:     noopThrottler{},
@@ -470,57 +472,29 @@ func (d *DAGStore) AllShardsInfo() AllShardsInfo {
 	return ret
 }
 
-// GC attempts to reclaim the transient files of shards that are currently
-// available but inactive.
+// GC performs DAG store garbage collection.
 //
-// It is not strictly atomic for now, as it determines which shards to reclaim
-// first, sends operations to the event loop, and waits for them to execute.
-// In the meantime, there could be state transitions that change reclaimability
-// of shards (some shards deemed reclaimable are no longer so, and vice versa).
+// This comprises two steps:
+//  1. Reclaim the transient files of shards that are currently available but
+//  inactive, or errored.
+//  2. Reconciles the transients directory with the mounts, by removing orphaned
+//  files (unreferenced files).
 //
-// However, the event loop checks for safety prior to deletion, so it will skip
-// over shards that are no longer safe to delete.
-func (d *DAGStore) GC(ctx context.Context) (map[shard.Key]error, error) {
-	var (
-		merr    *multierror.Error
-		reclaim []*Shard
-	)
-
-	d.lk.RLock()
-	for _, s := range d.shards {
-		s.lk.RLock()
-		if s.state == ShardStateAvailable || s.state == ShardStateErrored {
-			reclaim = append(reclaim, s)
-		}
-		s.lk.RUnlock()
-	}
-	d.lk.RUnlock()
-
-	var await int
-	ch := make(chan ShardResult, len(reclaim))
-	for _, s := range reclaim {
-		tsk := &task{op: OpShardGC, shard: s, waiter: &waiter{ctx: ctx, outCh: ch}}
-
-		err := d.queueTask(tsk, d.externalCh)
-		if err == nil {
-			await++
-		} else {
-			merr = multierror.Append(merr, fmt.Errorf("failed to enqueue GC task for shard %s: %w", s.key, err))
-		}
+// GC runs with exclusivity from the event loop.
+func (d *DAGStore) GC(ctx context.Context) (*GCResult, error) {
+	ch := make(chan *GCResult)
+	select {
+	case d.gcCh <- ch:
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 
-	// collect all results.
-	results := make(map[shard.Key]error, await)
-	for i := 0; i < await; i++ {
-		select {
-		case res := <-ch:
-			results[res.Key] = res.Error
-		case <-ctx.Done():
-			return results, ctx.Err()
-		}
+	select {
+	case res := <-ch:
+		return res, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-
-	return results, nil
 }
 
 func (d *DAGStore) Close() error {

--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -59,9 +59,10 @@ func (d *DAGStore) control() {
 		}
 
 		s := tsk.shard
-		prevState := s.state
-		log.Debugw("processing task", "op", tsk.op, "shard", tsk.shard.key, "state", prevState, "error", tsk.err)
+		log.Debugw("processing task", "op", tsk.op, "shard", tsk.shard.key, "error", tsk.err)
+
 		s.lk.Lock()
+		prevState := s.state
 
 		switch tsk.op {
 		case OpShardRegister:

--- a/dagstore_gc.go
+++ b/dagstore_gc.go
@@ -1,0 +1,101 @@
+package dagstore
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/filecoin-project/dagstore/shard"
+)
+
+// GCResult is the result of performing a GC operation. It holds the results
+// from deleting unused transients, and the result from reconciling the
+// transients dir with files referenced from mounts.
+type GCResult struct {
+	// Shards includes an entry for every shard whose transient was reclaimed.
+	// Nil error values indicate success.
+	Shards map[shard.Key]error
+	// Reconcile stores the result from the reconciliation phase.
+	Reconcile error
+}
+
+// ShardFailures returns the number of shards whose transient reclaim failed.
+func (e *GCResult) ShardFailures() int {
+	var failures int
+	for _, err := range e.Shards {
+		if err != nil {
+			failures++
+		}
+	}
+	return failures
+}
+
+// gc performs DAGStore GC. Refer to DAGStore#GC for more information.
+//
+// The event loops gives it exclusive execution rights, so while GC is running,
+// no other events are being processed.
+func (d *DAGStore) gc(resCh chan *GCResult) {
+	res := &GCResult{
+		Shards: make(map[shard.Key]error),
+	}
+
+	// A. Delete transients for unused and errored shards.
+
+	// determine which shards can be reclaimed.
+	d.lk.RLock()
+	var reclaim []*Shard
+	for _, s := range d.shards {
+		s.lk.RLock()
+		if nAcq := len(s.wAcquire); (s.state == ShardStateAvailable || s.state == ShardStateErrored) && nAcq == 0 {
+			reclaim = append(reclaim, s)
+		}
+		s.lk.RUnlock()
+	}
+	d.lk.RUnlock()
+
+	// attempt to delete transients of reclaimed shards.
+	for _, s := range reclaim {
+		s.lk.Lock()
+		err := s.mount.DeleteTransient()
+		if err != nil {
+			log.Warnw("failed to delete transient", "shard", s.key, "error", err)
+		}
+
+		// record the error so we can return it.
+		res.Shards[s.key] = err
+
+		// flush the shard state to the datastore.
+		if err := s.persist(d.config.Datastore); err != nil {
+			log.Warnw("failed to persist shard", "shard", s.key, "error", err)
+		}
+		s.lk.Unlock()
+	}
+
+	// B. Remove files that aren't referenced by the mounts.
+
+	referenced := make(map[string]struct{})
+	d.lk.RLock()
+	for _, s := range d.shards {
+		t, p := s.mount.TransientPath(), s.mount.PartialPath()
+		referenced[t] = struct{}{}
+		referenced[p] = struct{}{}
+	}
+	d.lk.RUnlock()
+
+	// Walk the transients dir and delete unreferenced files.
+	res.Reconcile = filepath.WalkDir(d.config.TransientsDir, func(path string, d fs.DirEntry, err error) error {
+		if _, ok := referenced[path]; !ok {
+			if err := os.Remove(path); err != nil {
+				log.Warnw("failed to garbage collec file", "path", path, "error", err)
+			} else {
+				log.Infow("garbage collected file", "path", path)
+			}
+		}
+		return nil
+	})
+
+	select {
+	case resCh <- res:
+	case <-d.ctx.Done():
+	}
+}

--- a/mount/upgrader.go
+++ b/mount/upgrader.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
+	"sync/atomic"
 
 	logging "github.com/ipfs/go-log/v2"
 )
@@ -27,16 +27,23 @@ type Upgrader struct {
 	key         string
 	passthrough bool
 
-	lk        sync.Mutex
-	transient string // guarded by lk
-	partial   string // guarded by lk
-	fetches   int    // guarded by lk
+	// paths: pathComplete is the path of transients that are
+	// completely downloaded; pathPartial is the path where in-progress
+	// downloads are placed. Once fully downloaded, the file is renamed to
+	// pathComplete.
+	pathComplete string
+	pathPartial  string
 
+	lk    sync.Mutex
+	path  string // guarded by lk
+	ready bool   // guarded by lk
 	// once guards deduplicates concurrent refetch requests; the caller that
 	// gets to run stores the result in onceErr, for other concurrent callers to
 	// consume it.
 	once    *sync.Once // guarded by lk
 	onceErr error      // NOT guarded by lk; access coordinated by sync.Once
+
+	fetches int32 // guarded by atomic
 }
 
 var _ Mount = (*Upgrader)(nil)
@@ -45,7 +52,14 @@ var _ Mount = (*Upgrader)(nil)
 // will reuse the file in path `initial` as the initial transient copy. Whenever
 // a new transient copy has to be created, it will be created under `rootdir`.
 func Upgrade(underlying Mount, rootdir, key string, initial string) (*Upgrader, error) {
-	ret := &Upgrader{underlying: underlying, key: key, rootdir: rootdir, once: new(sync.Once)}
+	ret := &Upgrader{
+		underlying:   underlying,
+		key:          key,
+		rootdir:      rootdir,
+		once:         new(sync.Once),
+		pathComplete: filepath.Join(rootdir, "transient-"+key+".complete"),
+		pathPartial:  filepath.Join(rootdir, "transient-"+key+".partial"),
+	}
 	if ret.rootdir == "" {
 		ret.rootdir = os.TempDir() // use the OS' default temp dir.
 	}
@@ -61,7 +75,8 @@ func Upgrade(underlying Mount, rootdir, key string, initial string) (*Upgrader, 
 	if initial != "" {
 		if _, err := os.Stat(initial); err == nil {
 			log.Debugw("initialized with existing transient that's alive", "shard", key, "path", initial)
-			ret.transient = initial
+			ret.path = initial
+			ret.ready = true
 			return ret, nil
 		}
 	}
@@ -79,18 +94,18 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 	// if not, delete it, get the current sync.Once and trigger a refresh.
 	// after it's done, open the resulting transient.
 	u.lk.Lock()
-	if u.transient != "" {
-		log.Debugw("transient copy exists; check liveness", "shard", u.key, "path", u.transient)
-		if _, err := os.Stat(u.transient); err == nil {
-			log.Debugw("transient copy alive; not refetching", "shard", u.key, "path", u.transient)
+	if u.ready {
+		log.Debugw("transient local copy exists; check liveness", "shard", u.key, "path", u.path)
+		if _, err := os.Stat(u.path); err == nil {
+			log.Debugw("transient copy alive; not refetching", "shard", u.key, "path", u.path)
 			defer u.lk.Unlock()
-			return os.Open(u.transient)
+			return os.Open(u.path)
 		} else {
-			log.Debugw("transient copy dead; removing and refetching", "shard", u.key, "path", u.transient, "error", err)
-			if err := os.Remove(u.transient); err != nil {
-				log.Warnw("refetch: failed to remove transient; garbage left behind", "shard", u.key, "dead_path", u.transient, "error", err)
+			u.ready = false
+			log.Debugw("transient copy dead; removing and refetching", "shard", u.key, "path", u.path, "error", err)
+			if err := os.Remove(u.path); err != nil {
+				log.Warnw("refetch: failed to remove transient; garbage left behind", "shard", u.key, "dead_path", u.path, "error", err)
 			}
-			u.transient = ""
 		}
 		// TODO add size check.
 	}
@@ -100,61 +115,56 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 	u.lk.Unlock()
 
 	once.Do(func() {
-		// create a temporary file, partial file, and track it.
-		// onceErr can be set outside the lock because access is exclusive due to sync.Once
-		var file *os.File
-		file, u.onceErr = os.CreateTemp(u.rootdir, "transient-"+u.key+"-*-partial")
+		// Create a new file in the partial location.
+		// os.Create truncates existing files.
+		var partial *os.File
+		partial, u.onceErr = os.Create(u.pathPartial)
 		if u.onceErr != nil {
 			return
 		}
-		defer file.Close()
-
-		u.lk.Lock()
-		u.fetches++
-		u.partial = file.Name()
-		u.lk.Unlock()
+		defer partial.Close()
 
 		// do the refetch; abort and remove/reset the partial if it fails.
 		// perform outside the lock as this is a long-running operation.
 		// u.onceErr is only written by the goroutine that gets to run sync.Once
 		// and it's only read after it finishes.
-		u.onceErr = u.refetch(ctx, file)
-
-		u.lk.Lock() // reacquire the lock, as we'll be modifying paths.
-		defer u.lk.Unlock()
-
+		u.onceErr = u.refetch(ctx, partial)
 		if u.onceErr != nil {
 			log.Warnw("failed to refetch", "shard", u.key, "error", u.onceErr)
-			if err := os.Remove(u.partial); err != nil {
-				log.Warnw("failed to remove partial transient", "shard", u.key, "path", u.partial, "error", err)
+			if err := os.Remove(u.pathPartial); err != nil {
+				log.Warnw("failed to remove partial transient", "shard", u.key, "path", u.pathPartial, "error", err)
 			}
-			u.partial = ""
 			return
 		}
 
 		// rename the partial file to a non-partial file.
 		// set the new transient path under a lock, and recycle the sync.Once.
-		final := strings.TrimSuffix(u.partial, "-partial")
-		if err := os.Rename(u.partial, final); err != nil {
-			log.Warnw("failed to rename partial transient", "shard", u.key, "from_path", u.partial, "to_path", final, "error", err)
-			final = u.partial // fall back to keeping the partial name.
+		// if the target file exists, os.Rename replaces it.
+		if err := os.Rename(u.pathPartial, u.pathComplete); err != nil {
+			log.Warnw("failed to rename partial transient", "shard", u.key, "from_path", u.pathPartial, "to_path", u.pathComplete, "error", err)
 		}
-		u.partial = ""
-		u.transient = final
-		u.once = new(sync.Once)
 
-		log.Debugw("transient path updated after refetching", "shard", u.key, "new_path", u.transient)
+		u.lk.Lock()
+		u.path = u.pathComplete
+		u.ready = true
+		u.once = new(sync.Once)
+		u.lk.Unlock()
+
+		log.Debugw("transient path updated after refetching", "shard", u.key, "new_path", u.pathComplete)
 	})
 
-	u.lk.Lock()
-	defer u.lk.Unlock()
-
-	if u.onceErr != nil {
-		return nil, fmt.Errorf("mount fetch failed: %w", u.onceErr)
+	// There's a tiny, tiny possibility of a race here if a new refetch with
+	// the recycled sync.Once comes in an updates onceErr before the waiters
+	// have read it. Not worth making perfect now, but we should revisit
+	// this recipe. Can probably use a sync.Cond with atomic counters.
+	// TODO revisit this.
+	err := u.onceErr
+	if err != nil {
+		return nil, fmt.Errorf("mount fetch failed: %w", err)
 	}
 
-	log.Debugw("refetched successfully", "shard", u.key, "path", u.transient)
-	return os.Open(u.transient)
+	log.Debugw("refetched successfully", "shard", u.key, "path", u.pathComplete)
+	return os.Open(u.pathComplete)
 }
 
 func (u *Upgrader) Info() Info {
@@ -167,8 +177,8 @@ func (u *Upgrader) Info() Info {
 }
 
 func (u *Upgrader) Stat(ctx context.Context) (Stat, error) {
-	if u.transient != "" {
-		if stat, err := os.Stat(u.transient); err == nil {
+	if u.path != "" {
+		if stat, err := os.Stat(u.path); err == nil {
 			ret := Stat{Exists: true, Size: stat.Size()}
 			return ret, nil
 		}
@@ -176,31 +186,18 @@ func (u *Upgrader) Stat(ctx context.Context) (Stat, error) {
 	return u.underlying.Stat(ctx)
 }
 
-// TransientPath returns the local path of the transient file, fully populated.
-// If the Upgrader is passthrough, the return value will be "".
+// TransientPath returns the local path of the transient file, if one exists.
 func (u *Upgrader) TransientPath() string {
 	u.lk.Lock()
 	defer u.lk.Unlock()
 
-	return u.transient
-}
-
-// PartialPath returns the local path of a partially populated transient. Will
-// be non-empty when the mount is being refetched.
-func (u *Upgrader) PartialPath() string {
-	u.lk.Lock()
-	defer u.lk.Unlock()
-
-	return u.partial
+	return u.path
 }
 
 // TimesFetched returns the number of times that the underlying has
 // been fetched.
 func (u *Upgrader) TimesFetched() int {
-	u.lk.Lock()
-	defer u.lk.Unlock()
-
-	return u.fetches
+	return int(atomic.LoadInt32(&u.fetches))
 }
 
 // Underlying returns the underlying mount.
@@ -223,7 +220,7 @@ func (u *Upgrader) Close() error {
 }
 
 func (u *Upgrader) refetch(ctx context.Context, into *os.File) error {
-	log.Debugw("actually refetching", "shard", u.key, "dead_path", u.transient)
+	log.Debugw("actually refetching", "shard", u.key, "path", into.Name())
 
 	// sanity check on underlying mount.
 	if stat, err := u.underlying.Stat(ctx); err != nil {
@@ -255,14 +252,14 @@ func (u *Upgrader) DeleteTransient() error {
 	u.lk.Lock()
 	defer u.lk.Unlock()
 
-	if u.transient == "" {
+	if u.path == "" {
 		log.Debugw("transient is empty; nothing to remove", "shard", u.key)
 		return nil // nothing to do.
 	}
 
 	// refuse to delete the transient if it's not being managed by us (i.e. in
 	// our transients root directory).
-	if _, err := filepath.Rel(u.rootdir, u.transient); err != nil {
+	if _, err := filepath.Rel(u.rootdir, u.path); err != nil {
 		log.Debugw("transient is not owned by us; nothing to remove", "shard", u.key)
 		return nil
 	}
@@ -270,8 +267,9 @@ func (u *Upgrader) DeleteTransient() error {
 	// remove the transient and clear it always, even if os.Remove
 	// returns an error. This allows us to recover from errors like the user
 	// deleting the transient we're currently tracking.
-	err := os.Remove(u.transient)
-	u.transient = ""
-	log.Debugw("deleted existing transient", "shard", u.key, "path", u.transient, "error", err)
+	err := os.Remove(u.path)
+	u.path = ""
+	u.ready = false
+	log.Debugw("deleted existing transient", "shard", u.key, "path", u.path, "error", err)
 	return err
 }

--- a/shard_persist.go
+++ b/shard_persist.go
@@ -22,7 +22,7 @@ type PersistedShard struct {
 }
 
 // MarshalJSON returns a serialized representation of the state. It must be
-// called with a shard lock (read, at lesat), such as from inside the event
+// called with a shard lock (read, at least), such as from inside the event
 // loop, as it accesses mutable state.
 func (s *Shard) MarshalJSON() ([]byte, error) {
 	u, err := s.d.mounts.Represent(s.mount)

--- a/shard_persist.go
+++ b/shard_persist.go
@@ -22,8 +22,8 @@ type PersistedShard struct {
 }
 
 // MarshalJSON returns a serialized representation of the state. It must be
-// called from inside the event loop, as it accesses mutable state, or under a
-// shard read lock.
+// called with a shard lock (read, at lesat), such as from inside the event
+// loop, as it accesses mutable state.
 func (s *Shard) MarshalJSON() ([]byte, error) {
 	u, err := s.d.mounts.Represent(s.mount)
 	if err != nil {
@@ -80,6 +80,8 @@ func (s *Shard) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// persist persists the shard's state into the supplied Datastore. It calls
+// MarshalJSON, which requires holding a shard lock to be safe.
 func (s *Shard) persist(store ds.Datastore) error {
 	ps, err := s.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
This PR closes #58.

It implements reconciliation of the transients directory, which consists of removing files that are no longer referenced by any mount, either as a complete or partial transient file.

We introduce the concept of a "partial file" in the Upgrader. The partial file is the file where a mount is being fetched into, while the fetch is in progress (cf. `.crdownload` in Chrome). This is not safe to expose as the `TransientPath`, because that would imply that it's fully functional. However, we don't want it saved in the Datastore.

I've also refactor the way that GC is triggered, so it's much neater now.