### PR TITLE
expose throttler so it can be embedded in mounts.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/filecoin-project/dagstore
 go 1.16
 
 require (
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.8-0.20210716091050-de6c03deae1c
 	github.com/ipfs/go-datastore v0.4.5

--- a/go.sum
+++ b/go.sum
@@ -131,12 +131,10 @@ github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfm
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/throttle/doc.go
+++ b/throttle/doc.go
@@ -1,0 +1,3 @@
+// Package throttle includes throttlers for composing in various contexts, such
+// as inside Mounts for costly operations, and within the DAG store itself.
+package throttle

--- a/throttle/throttler.go
+++ b/throttle/throttler.go
@@ -1,4 +1,4 @@
-package dagstore
+package throttle
 
 import "context"
 
@@ -18,9 +18,9 @@ type throttler struct {
 	ch chan struct{}
 }
 
-// NewThrottler creates a new throttler that allows the specified concurrency
+// Fixed creates a new throttler that allows the specified fixed concurrency
 // at most.
-func NewThrottler(maxConcurrency int) Throttler {
+func Fixed(maxConcurrency int) Throttler {
 	ch := make(chan struct{}, maxConcurrency)
 	for i := 0; i < maxConcurrency; i++ {
 		ch <- struct{}{}
@@ -36,6 +36,11 @@ func (t *throttler) Do(ctx context.Context, fn func(ctx context.Context) error) 
 	}
 	defer func() { t.ch <- struct{}{} }()
 	return fn(ctx)
+}
+
+// Noop returns a noop throttler.
+func Noop() Throttler {
+	return noopThrottler{}
 }
 
 type noopThrottler struct{}

--- a/throttle/throttler_test.go
+++ b/throttle/throttler_test.go
@@ -1,4 +1,4 @@
-package dagstore
+package throttle
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestThrottler(t *testing.T) {
-	tt := NewThrottler(5)
+	tt := Fixed(5)
 
 	var cnt int32
 	ch := make(chan struct{}, 16)


### PR DESCRIPTION
The global fetch throttling is insufficient for the nuanced things that a mount may need doing. For example, the Lotus mount will need to unseal pieces at times. Unsealing is a long process and cannot be subject to global throttling, else a single unsealing job can be head-of-line blocking for all retrievals, including those for already-unsealed pieces.

This preserves the global throttling for indexing and fetching, but exposes the throttler so it can be embedded into Mounts that do more precise throttling (e.g. the Lotus mount, which will throttle fetches of unsealed pieces only).