### PR TITLE
honour context cancellation on acquire.

### DIFF
--- a/dagstore.go
+++ b/dagstore.go
@@ -7,15 +7,16 @@ import (
 	"os"
 	"sync"
 
-	"github.com/filecoin-project/dagstore/index"
-	"github.com/filecoin-project/dagstore/mount"
-	"github.com/filecoin-project/dagstore/shard"
-	"github.com/filecoin-project/dagstore/throttle"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-datastore/query"
 	dssync "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/filecoin-project/dagstore/index"
+	"github.com/filecoin-project/dagstore/mount"
+	"github.com/filecoin-project/dagstore/shard"
+	"github.com/filecoin-project/dagstore/throttle"
 )
 
 var (

--- a/mount/upgrader_test.go
+++ b/mount/upgrader_test.go
@@ -222,18 +222,18 @@ func TestUpgraderDeduplicatesRemote(t *testing.T) {
 }
 
 func TestUpgraderFetchAndCopyThrottle(t *testing.T) {
-	 nFixedThrottle := 3
+	nFixedThrottle := 3
 
-	tcs := map[string]struct{
-		ready bool
+	tcs := map[string]struct {
+		ready                  bool
 		expectedThrottledReads int
 	}{
-		"no throttling when mount is not ready":{
-			ready: false,
+		"no throttling when mount is not ready": {
+			ready:                  false,
 			expectedThrottledReads: 100,
 		},
-		"throttle when mount is ready":{
-			ready: true,
+		"throttle when mount is ready": {
+			ready:                  true,
 			expectedThrottledReads: nFixedThrottle,
 		},
 	}
@@ -247,7 +247,7 @@ func TestUpgraderFetchAndCopyThrottle(t *testing.T) {
 
 			underlyings := make([]*blockingReaderMount, 100)
 			for i := range upgraders {
-				underlyings[i] = &blockingReaderMount{isReady:tc.ready, br: &blockingReader{r: io.LimitReader(rand2.Reader, 1)}}
+				underlyings[i] = &blockingReaderMount{isReady: tc.ready, br: &blockingReader{r: io.LimitReader(rand2.Reader, 1)}}
 				u, err := Upgrade(underlyings[i], thrt, t.TempDir(), "foo", "")
 				require.NoError(t, err)
 				upgraders[i] = u
@@ -326,7 +326,7 @@ func (br *blockingReader) Read(b []byte) (n int, err error) {
 
 type blockingReaderMount struct {
 	isReady bool
-	br *blockingReader
+	br      *blockingReader
 }
 
 var _ Mount = (*blockingReaderMount)(nil)
@@ -350,7 +350,7 @@ func (b *blockingReaderMount) Stat(ctx context.Context) (Stat, error) {
 	return Stat{
 		Exists: true,
 		Size:   1024,
-		Ready: b.isReady,
+		Ready:  b.isReady,
 	}, nil
 }
 

--- a/shard_state.go
+++ b/shard_state.go
@@ -34,12 +34,18 @@ const (
 )
 
 func (ss ShardState) String() string {
-	return [...]string{
+	strs := [...]string{
 		ShardStateNew:          "ShardStateNew",
 		ShardStateInitializing: "ShardStateInitializing",
 		ShardStateAvailable:    "ShardStateAvailable",
 		ShardStateServing:      "ShardStateServing",
 		ShardStateRecovering:   "ShardStateRecovering",
 		ShardStateErrored:      "ShardStateErrored",
-		ShardStateUnknown:      "ShardStateUnknown"}[ss]
+		ShardStateUnknown:      "ShardStateUnknown",
+	}
+	if ss < 0 || int(ss) >= len(strs) {
+		// safety comes first.
+		return "__undefined__"
+	}
+	return strs[ss]
 }


### PR DESCRIPTION
If the acquirer cancelled the context, we would never deliver the accessor and never release the shard. This was visible when testing out the new migration logic on Lotus and interrupting the `lotus dagstore initialize-all` command.