### PR TITLE
Fix markdown heading in design doc

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -69,7 +69,7 @@ populated:
 2. Indexless CARv2: the index is calculated upon shard activation.
 3. Indexed CARv2: the inline index is adopted as-is as the shard index.
 
-### Shard states
+### Shard states
 
 1. **Available:** the system knows about this shard and is capable of serving
    data from it instantaneously, because (a) an index exists and is loaded, and


### PR DESCRIPTION
Fix the rendering issue for a heading in the design doc: [before](https://github.com/filecoin-project/dagstore/blob/253211cf4b6cf2e2bfed1fb4ee07ca73baa50878/docs/design.md#car-formats) vs. [after](https://github.com/filecoin-project/dagstore/blob/9e61f02cc4dfa4ec00114b56c62d6ee30b7ba3ec/docs/design.md#car-formats)