### PR TITLE
Api to get iterable index from the DagStore

### DIFF
--- a/dagstore.go
+++ b/dagstore.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/filecoin-project/go-indexer-core/store/memory"
 
-	"github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/dagstore/invertedindex"
 
 	ds "github.com/ipfs/go-datastore"
@@ -208,7 +206,7 @@ func NewDAGStore(cfg Config) (*DAGStore, error) {
 	}
 
 	if cfg.InvertedIndex == nil {
-		log.Warn("using in-memory inverted index")
+		log.Info("using in-memory inverted index")
 		cfg.InvertedIndex = invertedindex.NewIndexerCore(memory.New())
 	}
 
@@ -340,7 +338,7 @@ func (d *DAGStore) Start(ctx context.Context) error {
 func (d *DAGStore) GetIterableIndex(key shard.Key) (carindex.IterableIndex, error) {
 	fi, err := d.indices.GetFullIndex(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get iterable index: %w", err)
 	}
 
 	ii, ok := fi.(carindex.IterableIndex)
@@ -351,11 +349,7 @@ func (d *DAGStore) GetIterableIndex(key shard.Key) (carindex.IterableIndex, erro
 	return ii, nil
 }
 
-func (d *DAGStore) GetShardKeysForCid(c cid.Cid) ([]shard.Key, error) {
-	return d.invertedIndex.GetShardsForMultihash(c.Hash())
-}
-
-func (d *DAGStore) GetShardKeysForMultihash(h mh.Multihash) ([]shard.Key, error) {
+func (d *DAGStore) ShardsContainingMultihash(h mh.Multihash) ([]shard.Key, error) {
 	return d.invertedIndex.GetShardsForMultihash(h)
 }
 

--- a/dagstore_test.go
+++ b/dagstore_test.go
@@ -168,7 +168,7 @@ func TestRegisterCarV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ii)
 	err = ii.ForEach(func(h multihash.Multihash, _ uint64) error {
-		k2, err := dagst.GetShardKeysForMultihash(h)
+		k2, err := dagst.ShardsContainingMultihash(h)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.4.5
 	github.com/ipfs/go-log/v2 v2.3.0
-	github.com/ipld/go-car/v2 v2.0.3-0.20210910134712-2d2568297f26
+	github.com/ipld/go-car/v2 v2.1.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61
 	github.com/multiformats/go-multihash v0.0.16
@@ -17,4 +17,5 @@ require (
 	golang.org/x/exp v0.0.0-20210714144626-1041f73d31d8
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+	gopkg.in/yaml.v2 v2.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipld/go-car v0.1.0 h1:AaIEA5ITRnFA68uMyuIPYGM2XXllxsu8sNjFJP797us=
 github.com/ipld/go-car v0.1.0/go.mod h1:RCWzaUh2i4mOEkB3W45Vc+9jnS/M6Qay5ooytiBHl3g=
-github.com/ipld/go-car/v2 v2.0.3-0.20210910134712-2d2568297f26 h1:IBXjeOANJGYZVJ9jsvf0Tu+ANQ9FLstscJgzfJgwA8c=
-github.com/ipld/go-car/v2 v2.0.3-0.20210910134712-2d2568297f26/go.mod h1:bBmZNBj4jfOHrd4Cu/koFhqwsCnZ5RrGXU1wwWqDr20=
+github.com/ipld/go-car/v2 v2.1.0 h1:t8R/WXUSkfu1K1gpPk76mytCxsEdMjGcMIgpOq3/Cnw=
+github.com/ipld/go-car/v2 v2.1.0/go.mod h1:Xr6GwkDhv8dtOtgHzOynAkIOg0t0YiPc5DxBPppWqZA=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-storethehash v0.0.0-20210825183827-efb212b402c8/go.mod h1:PwE6iq8TiWJRI3zMGA1RtkFAnrDMK93dLA5SUeu0lH8=
@@ -543,7 +543,6 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=

--- a/interface.go
+++ b/interface.go
@@ -3,7 +3,7 @@ package dagstore
 import (
 	"context"
 
-	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 
 	"github.com/filecoin-project/dagstore/mount"
 	"github.com/filecoin-project/dagstore/shard"
@@ -19,7 +19,7 @@ type Interface interface {
 	RecoverShard(ctx context.Context, key shard.Key, out chan ShardResult, _ RecoverOpts) error
 	GetShardInfo(k shard.Key) (ShardInfo, error)
 	AllShardsInfo() AllShardsInfo
-	GetShardKeysForCid(c cid.Cid) ([]shard.Key, error)
+	ShardsContainingMultihash(h mh.Multihash) ([]shard.Key, error)
 	GC(ctx context.Context) (*GCResult, error)
 	Close() error
 }

--- a/invertedindex/indexer_core.go
+++ b/invertedindex/indexer_core.go
@@ -1,1 +1,0 @@
-package invertedindex


### PR DESCRIPTION
We should be able to get an iterable index out of the dagstore so the reference provider can serve the index to the network indexer.