### PR TITLE
Sugar syntax for acquiring a shard and logging the trace loop

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -62,3 +62,22 @@ func RecoverImmediately(ctx context.Context, dagst *DAGStore, failureCh chan Sha
 		}
 	}
 }
+
+// LogTraceLoop logs the output of the given trace channel until the given context expires.
+func LogTraceLoop(ctx context.Context, traceCh chan Trace, onDone func()) {
+	defer onDone()
+
+	for {
+		select {
+		// Log trace events from the DAG store
+		case tr := <-traceCh:
+			log.Debugw("trace",
+				"shard-key", tr.Key.String(),
+				"op-type", tr.Op.String(),
+				"after", tr.After.String())
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/helpers/shard.go
+++ b/helpers/shard.go
@@ -8,6 +8,9 @@ import (
 	"github.com/filecoin-project/dagstore/shard"
 )
 
+// AcquireShardSync blocks until the requested shard is acquired or the given context expires.
+// It returns the acquired shard if the acquire was successful. It is the caller's responsibility
+// to close the returned accessor when done.
 func AcquireShardSync(ctx context.Context, dagst *dagstore.DAGStore, sk shard.Key) (*dagstore.ShardAccessor, error) {
 	ch := make(chan dagstore.ShardResult, 1)
 

--- a/helpers/shard.go
+++ b/helpers/shard.go
@@ -1,0 +1,30 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filecoin-project/dagstore"
+	"github.com/filecoin-project/dagstore/shard"
+)
+
+func AcquireShardSync(ctx context.Context, dagst *dagstore.DAGStore, sk shard.Key) (*dagstore.ShardAccessor, error) {
+	ch := make(chan dagstore.ShardResult, 1)
+
+	if err := dagst.AcquireShard(ctx, sk, ch, dagstore.AcquireOpts{}); err != nil {
+		return nil, fmt.Errorf("failed to acquire shard: %w", err)
+	}
+
+	var res dagstore.ShardResult
+	select {
+	case res = <-ch:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	if err := res.Error; err != nil {
+		return nil, fmt.Errorf("failed to acquire shard: %w", err)
+	}
+
+	return res.Accessor, nil
+}

--- a/shard/key.go
+++ b/shard/key.go
@@ -30,6 +30,11 @@ func KeyFromCID(cid cid.Cid) Key {
 	return Key{str: cid.String()}
 }
 
+// KeyFromCIDMultihash returns a key based on the multihash of the given cid.
+func KeyFromCIDMultihash(cid cid.Cid) Key {
+	return KeyFromString(cid.Hash().String())
+}
+
 // String returns the string representation for this key.
 func (k Key) String() string {
 	return k.str


### PR DESCRIPTION
Just some sugar syntax to synchronously acquiring a shard and for logging the trace loop in debug mode.