### PR TITLE
[WIP] Automated LRU GC sketch PR

### DIFF
--- a/dagstore.go
+++ b/dagstore.go
@@ -183,6 +183,12 @@ type Config struct {
 	// RecoverOnStart specifies whether failed shards should be recovered
 	// on start.
 	RecoverOnStart RecoverOnStartPolicy
+
+	MaxTransientSize int64
+
+	TransientsGCWatermarkHigh float64
+
+	TransientsGCWatermarkLow float64
 }
 
 // NewDAGStore constructs a new DAG store with the supplied configuration.

--- a/shard.go
+++ b/shard.go
@@ -3,6 +3,7 @@ package dagstore
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/filecoin-project/dagstore/mount"
 	"github.com/filecoin-project/dagstore/shard"
@@ -54,4 +55,6 @@ type Shard struct {
 	wDestroy  *waiter   // waiter for shard destruction.
 
 	refs uint32 // number of DAG accessors currently open
+
+	lastAccessedAt time.Time
 }


### PR DESCRIPTION
The problem with automated LRU GC is that it can also GC shards that are being served/initialised. This will fail the ongoing initialise/acquire/blockstore read operations for those shards. We simply look at the directory size and keep removing transients till we hit our target. We can launch with this for V0 and fix it down the line.

Clients who are not okay with interrupting existing shard acquires/initialisation can continue using the existing manual but safe GC mechanism for now.

It's hard to make the automated LRU GC thread safe with the async shard acquire and shard init ops as they write to the transient directory in their own go-routine outside the dagstore event loop. The way the existing manual GC mechanism gets away with this is by ignoring shards that are being initialised or served.

The other thing to note here is that we may not always have Mounts that can tell you the size of the CAR upfront because the CAR maybe the result of a remote (root, selector) traversal and the size will be known only upon fetching the subDAG as a result of a remote traversal.  One example of this is the IPFS Gateway which does NOT have a HEAD method to know the size of a (root, selector) CAR upfront. It only exposes a GET API to stream the result of a (root, selector) traversal but does NOT have a HEAD method to know the size upfront. This makes the reactive "evict before a Mount fetch" strategy hard to implement. The simple thing to do here is to always run the GC proactively in the dagstore event loop when we detect watermark breach.