### PR TITLE
feat: add unified-ci

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,11 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+name: Automerge
+on: [ pull_request ]
+
+jobs:
+  automerge:
+    uses: protocol/.github/.github/workflows/automerge.yml@master
+    with:
+      job: 'automerge'

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -1,0 +1,73 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+on: [push, pull_request]
+name: Go Checks
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    name: All
+    env:
+      RUNGOGENERATE: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19.x"
+      - name: Run repo-specific setup
+        uses: ./.github/actions/go-check-setup
+        if: hashFiles('./.github/actions/go-check-setup') != ''
+      - name: Read config
+        if: hashFiles('./.github/workflows/go-check-config.json') != ''
+        run: |
+          if jq -re .gogenerate ./.github/workflows/go-check-config.json; then
+            echo "RUNGOGENERATE=true" >> $GITHUB_ENV
+          fi
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@376210a89477dedbe6fdc4484b233998650d7b3c # 2022.1.3 (v0.3.3)
+      - name: Check that go.mod is tidy
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: |
+            go mod tidy
+            if [[ -n $(git ls-files --other --exclude-standard --directory -- go.sum) ]]; then
+              echo "go.sum was added by go mod tidy"
+              exit 1
+            fi
+            git diff --exit-code -- go.sum go.mod
+      - name: gofmt
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        run: |
+          out=$(gofmt -s -l .)
+          if [[ -n "$out" ]]; then
+            echo $out | awk '{print "::error file=" $0 ",line=0,col=0::File is not gofmt-ed."}'
+            exit 1
+          fi
+      - name: go vet
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: go vet ./...
+      - name: staticcheck
+        if: ${{ success() || failure() }} # run this step even if the previous one failed
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: |
+            set -o pipefail
+            staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
+      - name: go generate
+        uses: protocol/multiple-go-modules@v1.2
+        if: (success() || failure()) && env.RUNGOGENERATE == 'true'
+        with:
+          run: |
+            git clean -fd # make sure there aren't untracked files / directories
+            go generate ./...
+            # check if go generate modified or added any files
+            if ! $(git add . && git diff-index HEAD --exit-code --quiet); then
+              echo "go generated caused changes to the repository:"
+              git status --short
+              exit 1
+            fi

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,68 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+on: [push, pull_request]
+name: Go Test
+
+jobs:
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu", "windows", "macos" ]
+        go: [ "1.18.x", "1.19.x" ]
+    env:
+      COVERAGES: ""
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    name: ${{ matrix.os }} (go ${{ matrix.go }})
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Go information
+        run: |
+          go version
+          go env
+      - name: Use msys2 on windows
+        if: ${{ matrix.os == 'windows' }}
+        shell: bash
+        # The executable for msys2 is also called bash.cmd
+        #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#shells
+        # If we prepend its location to the PATH
+        #   subsequent 'shell: bash' steps will use msys2 instead of gitbash
+        run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
+      - name: Run repo-specific setup
+        uses: ./.github/actions/go-test-setup
+        if: hashFiles('./.github/actions/go-test-setup') != ''
+      - name: Run tests
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          # Use -coverpkg=./..., so that we include cross-package coverage.
+          # If package ./A imports ./B, and ./A's tests also cover ./B,
+          # this means ./B's coverage will be significantly higher than 0%.
+          run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
+      - name: Run tests (32 bit)
+        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
+        uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOARCH: 386
+        with:
+          run: |
+            export "PATH=${{ env.PATH_386 }}:$PATH"
+            go test -v -shuffle=on ./...
+      - name: Run tests with race detector
+        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: go test -v -race ./...
+      - name: Collect coverage files
+        shell: bash
+        run: echo "COVERAGES=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_ENV
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+        with:
+          files: '${{ env.COVERAGES }}'
+          env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,11 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+name: Release Checker
+on:
+  pull_request:
+    paths: [ 'version.json' ]
+
+jobs:
+  release-check:
+    uses: protocol/.github/.github/workflows/release-check.yml@master

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,11 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+name: Releaser
+on:
+  push:
+    paths: [ 'version.json' ]
+
+jobs:
+  releaser:
+    uses: protocol/.github/.github/workflows/releaser.yml@master

--- a/.github/workflows/tagpush.yml
+++ b/.github/workflows/tagpush.yml
@@ -1,0 +1,12 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+name: Tag Push Checker
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  releaser:
+    uses: protocol/.github/.github/workflows/tagpush.yml@master

--- a/accessor_test.go
+++ b/accessor_test.go
@@ -31,6 +31,10 @@ import (
 // capable of returning *os.File as a mount.Reader will end up being mmapped.
 // Both the FileMount and the Upgrader fall in that category.
 func TestMmap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows")
+	}
+
 	run := func(t *testing.T, mnt mount.Mount, expect bool, name string) {
 		ctx := context.TODO()
 		// create three shard accessors, with a blockstore each.

--- a/dagstore.go
+++ b/dagstore.go
@@ -460,7 +460,8 @@ type RecoverOpts struct {
 // will be notified when it completes.
 //
 // TODO add an operation identifier to ShardResult -- starts to look like
-//  a Trace event?
+//
+//	a Trace event?
 func (d *DAGStore) RecoverShard(ctx context.Context, key shard.Key, out chan ShardResult, _ RecoverOpts) error {
 	d.lk.Lock()
 	s, ok := d.shards[key]

--- a/dagstore_test.go
+++ b/dagstore_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -94,6 +95,10 @@ func TestDestroyShard(t *testing.T) {
 
 	info := dagst.AllShardsInfo()
 	require.Equal(t, 1, len(info))
+
+	// clean up active shard
+	require.NotNil(t, res.Accessor)
+	require.NoError(t, res.Accessor.Close())
 }
 
 func TestRegisterUsingExistingTransient(t *testing.T) {
@@ -361,6 +366,10 @@ func TestConcurrentAcquires(t *testing.T) {
 }
 
 func TestRestartRestoresState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows - TODO: release open shard resource on dagstore close")
+	}
+
 	dir := t.TempDir()
 	store := datastore.NewLogDatastore(dssync.MutexWrap(datastore.NewMapDatastore()), "trace")
 	idx, err := index.NewFSRepo(t.TempDir())
@@ -427,6 +436,10 @@ func TestRestartRestoresState(t *testing.T) {
 }
 
 func TestRestartResumesRegistration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows - TODO: release open shard resource on dagstore close")
+	}
+
 	dir := t.TempDir()
 	store := datastore.NewLogDatastore(dssync.MutexWrap(datastore.NewMapDatastore()), "trace")
 	r := testRegistry(t)
@@ -543,6 +556,10 @@ func TestRestartResumesRegistration(t *testing.T) {
 }
 
 func TestGC(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows - TODO: release open shard resource on dagstore close")
+	}
+
 	dir := t.TempDir()
 	dagst, err := NewDAGStore(Config{
 		MountRegistry: testRegistry(t),
@@ -622,6 +639,10 @@ func TestOrphansRemovedOnStartup(t *testing.T) {
 // TestLazyInitialization tests that lazy initialization initializes shards on
 // their first acquisition.
 func TestLazyInitialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows - TODO: release open shard resource on dagstore close")
+	}
+
 	dir := t.TempDir()
 	store := datastore.NewLogDatastore(dssync.MutexWrap(datastore.NewMapDatastore()), "trace")
 	sink := tracer(128)
@@ -670,6 +691,10 @@ func TestLazyInitialization(t *testing.T) {
 // TestThrottleFetch exercises and tests the fetch concurrency limitation.
 // Testing thottling on indexing is way harder...
 func TestThrottleFetch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows - TODO: release open shard resource on dagstore close")
+	}
+
 	r := testRegistry(t)
 	err := r.Register("block", newBlockingMount(&mount.FSMount{FS: testdata.FS}))
 	require.NoError(t, err)
@@ -735,6 +760,8 @@ func TestThrottleFetch(t *testing.T) {
 	require.Len(t, m, 2) // only two shard states.
 	require.Len(t, m[ShardStateInitializing], 16-5)
 	require.Len(t, m[ShardStateAvailable], 5)
+
+	require.NoError(t, dagst.Close())
 }
 
 func TestIndexingFailure(t *testing.T) {
@@ -917,15 +944,16 @@ func TestIndexingFailure(t *testing.T) {
 			require.NoError(t, res.Error)
 			require.Equal(t, k, res.Key)
 			require.NotNil(t, res.Accessor)
+			require.NoError(t, res.Accessor.Close())
 		}
 
-		evts := make([]Trace, 48)
+		evts := make([]Trace, 54)
 		n, timedOut := sink.Read(evts, 50*time.Millisecond)
 		require.False(t, timedOut)
-		require.Equal(t, 48, n)
+		require.Equal(t, 54, n)
 
-		// these 48 traces are OpShardRecover, OpShardFail.
-		for i := 0; i < 48; i++ {
+		// these 54 traces are OpShardRecover, OpShardMakeAvailable, OpShardAcquire and OpShardRelease.
+		for i := 0; i < 54; i++ {
 			evt := evts[i]
 			switch evt.Op {
 			case OpShardRecover:
@@ -937,11 +965,16 @@ func TestIndexingFailure(t *testing.T) {
 			case OpShardAcquire:
 				require.EqualValues(t, ShardStateServing, evt.After.ShardState)
 				require.NoError(t, evt.After.Error)
+			case OpShardRelease:
+				require.EqualValues(t, ShardStateAvailable, evt.After.ShardState)
+				require.NoError(t, evt.After.Error)
 			default:
 				t.Fatalf("unexpected op: %s", evt.Op)
 			}
 		}
 	})
+
+	require.NoError(t, dagst.Close())
 }
 
 func TestFailureRecovery(t *testing.T) {
@@ -1279,9 +1312,12 @@ func TestTransientReusedOnRestart(t *testing.T) {
 	res = <-ch
 	require.NoError(t, res.Error)
 	require.NotNil(t, res.Accessor)
+	require.NoError(t, res.Accessor.Close())
 
 	// ensure that the count has not been incremented (i.e. the origin was not accessed)
 	require.Zero(t, dagst.shards[k].mount.TimesFetched())
+
+	require.NoError(t, dagst.Close())
 }
 
 func TestAcquireFailsWhenIndexGone(t *testing.T) {
@@ -1346,6 +1382,10 @@ func TestWaiterContextCancelled(t *testing.T) {
 }
 
 func TestAcquireContextCancelled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on Windows - TODO: release shard accessor on context cancellation")
+	}
+
 	r := testRegistry(t)
 	err := r.Register("block", newBlockingMount(&mount.FSMount{FS: testdata.FS}))
 	require.NoError(t, err)
@@ -1403,6 +1443,7 @@ func TestAcquireContextCancelled(t *testing.T) {
 	err = res.Accessor.Close()
 	require.NoError(t, err)
 
+	require.NoError(t, dagst.Close())
 }
 
 // registerShards registers n shards concurrently, using the CARv2 mount.

--- a/dagstore_test.go
+++ b/dagstore_test.go
@@ -1161,7 +1161,6 @@ func TestRecoveryOnStart(t *testing.T) {
 		require.True(t, timedOut)
 		require.Equal(t, 16, n)
 
-		counts = map[OpType]int{}
 		for _, evt := range evts[:16] {
 			require.Equal(t, OpShardAcquire, evt.Op)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/dagstore
 
-go 1.16
+go 1.18
 
 require (
 	github.com/ipfs/go-block-format v0.0.3
@@ -10,9 +10,8 @@ require (
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipld/go-car/v2 v2.1.1
-	github.com/libp2p/go-libp2p-core v0.9.0 // indirect
 	github.com/mr-tron/base58 v1.2.0
-	github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61
+	github.com/multiformats/go-multicodec v0.5.0
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
@@ -20,4 +19,50 @@ require (
 	golang.org/x/exp v0.0.0-20210714144626-1041f73d31d8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/ipfs/bbloom v0.0.4 // indirect
+	github.com/ipfs/go-blockservice v0.2.1 // indirect
+	github.com/ipfs/go-ipfs-blockstore v1.1.2 // indirect
+	github.com/ipfs/go-ipfs-ds-help v1.1.0 // indirect
+	github.com/ipfs/go-ipfs-exchange-interface v0.1.0 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
+	github.com/ipfs/go-ipld-cbor v0.0.5 // indirect
+	github.com/ipfs/go-ipld-format v0.2.0 // indirect
+	github.com/ipfs/go-ipld-legacy v0.1.0 // indirect
+	github.com/ipfs/go-log v1.0.5 // indirect
+	github.com/ipfs/go-merkledag v0.5.1 // indirect
+	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
+	github.com/ipfs/go-verifcid v0.0.1 // indirect
+	github.com/ipld/go-codec-dagpb v1.3.0 // indirect
+	github.com/ipld/go-ipld-prime v0.14.0 // indirect
+	github.com/jbenet/goprocess v0.1.4 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.13 // indirect
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
+	github.com/multiformats/go-base32 v0.0.3 // indirect
+	github.com/multiformats/go-base36 v0.1.0 // indirect
+	github.com/multiformats/go-multibase v0.0.3 // indirect
+	github.com/multiformats/go-varint v0.0.6 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.7.0 // indirect
+	go.uber.org/zap v1.16.0 // indirect
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	lukechampine.com/blake3 v1.1.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -449,9 +449,8 @@ github.com/libp2p/go-libp2p-core v0.7.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJB
 github.com/libp2p/go-libp2p-core v0.8.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
 github.com/libp2p/go-libp2p-core v0.8.1/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
 github.com/libp2p/go-libp2p-core v0.8.2/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
+github.com/libp2p/go-libp2p-core v0.8.5 h1:aEgbIcPGsKy6zYcC+5AJivYFedhYa4sW7mIpWpUaLKw=
 github.com/libp2p/go-libp2p-core v0.8.5/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
-github.com/libp2p/go-libp2p-core v0.9.0 h1:t97Mv0LIBZlP2FXVRNKKVzHJCIjbIWGxYptGId4+htU=
-github.com/libp2p/go-libp2p-core v0.9.0/go.mod h1:ESsbz31oC3C1AvMJoGx26RTuCkNhmkSRCqZ0kQtJ2/8=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfxg97AEdo4GYBt6BadWg=
 github.com/libp2p/go-libp2p-discovery v0.3.0/go.mod h1:o03drFnz9BVAZdzC/QUQ+NeQOu38Fu7LJGEOK2gQltw=
@@ -664,8 +663,9 @@ github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/g
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
-github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61 h1:ZrUuMKNgJ52qHPoQ+bx0h0uBfcWmN7Px+4uKSZeesiI=
 github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61/go.mod h1:1Hj/eHRaVWSXiSNNfcEPcwZleTmdNP81xlxDLnWU9GQ=
+github.com/multiformats/go-multicodec v0.5.0 h1:EgU6cBe/D7WRwQb1KmnBvU7lrcFGMggZVTPtOW9dDHs=
+github.com/multiformats/go-multicodec v0.5.0/go.mod h1:DiY2HFaEp5EhEXb/iYzVAunmyX/aSFMxq2KMKfWEues=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/index/inverted_index_impl_test.go
+++ b/index/inverted_index_impl_test.go
@@ -63,6 +63,8 @@ func TestLevelDBBatch(t *testing.T) {
 		require.Len(t, sk, 1)
 		require.Contains(t, sk, sk1)
 	}
+
+	require.NoError(t, dstore.Close())
 }
 
 func TestDatastoreIndex(t *testing.T) {

--- a/index/repo_fs_test.go
+++ b/index/repo_fs_test.go
@@ -27,6 +27,7 @@ func TestFSRepoVersions(t *testing.T) {
 
 	// Expect the repo to have been initialized with the correct version
 	bs, err := os.ReadFile(repo.versionPath())
+	require.NoError(t, err)
 	require.Equal(t, repoVersion, string(bs))
 
 	// Verify we can create a new repo at the same path
@@ -36,6 +37,7 @@ func TestFSRepoVersions(t *testing.T) {
 	// Verify that creating a repo at a path with a higher different version
 	// returns an error
 	err = os.WriteFile(repo.versionPath(), []byte("2"), 0666)
+	require.NoError(t, err)
 	_, err = NewFSRepo(basePath)
 	require.Error(t, err)
 }

--- a/index/repo_test.go
+++ b/index/repo_test.go
@@ -42,9 +42,11 @@ func (s *fullIndexRepoSuite) TestAllMethods() {
 	require.EqualValues(t, 0, stat.Size)
 
 	l, err := r.Len()
+	require.NoError(t, err)
 	require.EqualValues(t, 0, l)
 
 	size, err := r.Size()
+	require.NoError(t, err)
 	require.EqualValues(t, 0, size)
 
 	// Verify that there is an error trying to retrieve an index before it's added
@@ -56,6 +58,7 @@ func (s *fullIndexRepoSuite) TestAllMethods() {
 	require.NoError(t, err)
 
 	l, err = r.Len()
+	require.NoError(t, err)
 	require.EqualValues(t, 1, l)
 
 	// Verify the size of the index is correct
@@ -70,6 +73,7 @@ func (s *fullIndexRepoSuite) TestAllMethods() {
 	require.EqualValues(t, expStatSize, stat.Size)
 
 	size, err = r.Size()
+	require.NoError(t, err)
 	require.EqualValues(t, expStatSize, size)
 
 	count := 0
@@ -103,8 +107,10 @@ func (s *fullIndexRepoSuite) TestAllMethods() {
 	require.EqualValues(t, 0, stat.Size)
 
 	l, err = r.Len()
+	require.NoError(t, err)
 	require.EqualValues(t, 0, l)
 
 	size, err = r.Size()
+	require.NoError(t, err)
 	require.EqualValues(t, 0, size)
 }

--- a/mount/file_test.go
+++ b/mount/file_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ func TestFileMount(t *testing.T) {
 
 	// create a temp file.
 	dir := t.TempDir()
-	f, err := ioutil.TempFile(dir, "")
+	f, err := os.CreateTemp(dir, "")
 	require.NoError(t, err)
 	defer f.Close()
 
@@ -53,7 +53,7 @@ func TestFileMount(t *testing.T) {
 	require.Equal(t, b.Bytes(), read[:i])
 
 	// seek to the beginning and read the first byte.
-	n, err = reader.Seek(0, 0)
+	_, err = reader.Seek(0, 0)
 	require.NoError(t, err)
 	var b1 [1]byte
 	i, err = reader.Read(b1[:])

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -56,9 +56,9 @@ const (
 //
 // MountTypes must define a deterministic URL representation which will be used to:
 //
-//  a. deserialise the Mount from DAG persistence when resuming the system by
-//     using a pre-defined Mount factory mapped to the URL scheme.
-//  b. support adding mounts from configuration files.
+//	a. deserialise the Mount from DAG persistence when resuming the system by
+//	   using a pre-defined Mount factory mapped to the URL scheme.
+//	b. support adding mounts from configuration files.
 type Mount interface {
 	io.Closer
 

--- a/mount/registry_test.go
+++ b/mount/registry_test.go
@@ -3,7 +3,7 @@ package mount
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -26,7 +26,9 @@ func (m *MockMount) Serialize() *url.URL {
 		Scheme: "aaa", // random, will get replaced
 		Host:   m.Val,
 	}
-	u.Query().Set("size", strconv.FormatInt(m.StatSize, 10))
+	q := u.Query()
+	q.Set("size", strconv.FormatInt(m.StatSize, 10))
+	u.RawQuery = q.Encode()
 	return u
 }
 
@@ -161,7 +163,7 @@ func TestRegistryRecognizedType(t *testing.T) {
 func fetchAndReadAll(t *testing.T, m Mount) string {
 	rd, err := m.Fetch(context.Background())
 	require.NoError(t, err)
-	bz, err := ioutil.ReadAll(rd)
+	bz, err := io.ReadAll(rd)
 	require.NoError(t, err)
 	return string(bz)
 }

--- a/mount/upgrader.go
+++ b/mount/upgrader.go
@@ -125,7 +125,6 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 		if u.onceErr != nil {
 			return
 		}
-		defer partial.Close()
 
 		// do the refetch; abort and remove/reset the partial if it fails.
 		// perform outside the lock as this is a long-running operation.
@@ -133,6 +132,7 @@ func (u *Upgrader) Fetch(ctx context.Context) (Reader, error) {
 		// and it's only read after it finishes.
 
 		u.onceErr = u.refetch(ctx, partial)
+		partial.Close()
 		if u.onceErr != nil {
 			log.Warnw("failed to refetch", "shard", u.key, "error", u.onceErr)
 			if err := os.Remove(u.pathPartial); err != nil {

--- a/mount/upgrader_test.go
+++ b/mount/upgrader_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -37,7 +36,7 @@ func TestUpgrade(t *testing.T) {
 				return &FileMount{"../" + testdata.RootPathCarV1}
 			},
 			verify: func(t *testing.T, u *Upgrader, key string, rootDir string) {
-				fs, err := ioutil.ReadDir(rootDir)
+				fs, err := os.ReadDir(rootDir)
 				require.NoError(t, err)
 				require.Empty(t, fs)
 				_, err = os.Stat(u.TransientPath())
@@ -61,7 +60,7 @@ func TestUpgrade(t *testing.T) {
 				tf, err := os.Open(u.TransientPath())
 				require.NoError(t, err)
 				defer tf.Close()
-				bz, err := ioutil.ReadAll(tf)
+				bz, err := io.ReadAll(tf)
 				require.NoError(t, err)
 				require.NoError(t, tf.Close())
 
@@ -69,7 +68,7 @@ func TestUpgrade(t *testing.T) {
 				f, err := os.Open("../" + testdata.RootPathCarV1)
 				require.NoError(t, err)
 				defer f.Close()
-				bz2, err := ioutil.ReadAll(f)
+				bz2, err := io.ReadAll(f)
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 				require.EqualValues(t, bz, bz2)
@@ -123,14 +122,14 @@ func TestUpgrade(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, rd)
 
-			bz, err := ioutil.ReadAll(rd)
+			bz, err := io.ReadAll(rd)
 			require.NoError(t, err)
 			require.NotEmpty(t, bz)
 			require.NoError(t, rd.Close())
 
 			f, err := os.Open(tcc.expectedContentFilePath)
 			require.NoError(t, err)
-			bz2, err := ioutil.ReadAll(f)
+			bz2, err := io.ReadAll(f)
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
 			require.EqualValues(t, bz2, bz)
@@ -174,7 +173,7 @@ func TestUpgraderDeduplicatesRemote(t *testing.T) {
 
 	carF, err := os.Open("../" + testdata.RootPathCarV2)
 	require.NoError(t, err)
-	carBytes, err := ioutil.ReadAll(carF)
+	carBytes, err := io.ReadAll(carF)
 	require.NoError(t, err)
 	require.NoError(t, carF.Close())
 
@@ -182,7 +181,7 @@ func TestUpgraderDeduplicatesRemote(t *testing.T) {
 	for _, rd := range readers {
 		rdc := rd
 		grp2.Go(func() error {
-			bz, err := ioutil.ReadAll(rdc)
+			bz, err := io.ReadAll(rdc)
 			if err != nil {
 				return err
 			}

--- a/mount/upgrader_test.go
+++ b/mount/upgrader_test.go
@@ -261,7 +261,10 @@ func TestUpgraderFetchAndCopyThrottle(t *testing.T) {
 			for _, u := range upgraders {
 				u := u
 				errgrp.Go(func() error {
-					_, err := u.Fetch(ctx)
+					f, err := u.Fetch(ctx)
+					if f != nil {
+						defer f.Close()
+					}
 					return err
 				})
 			}

--- a/shard.go
+++ b/shard.go
@@ -51,7 +51,6 @@ type Shard struct {
 	wRegister *waiter   // waiter for registration result.
 	wRecover  *waiter   // waiter for recovering an errored shard.
 	wAcquire  []*waiter // waiters for acquiring the shard.
-	wDestroy  *waiter   // waiter for shard destruction.
 
 	refs uint32 // number of DAG accessors currently open
 }

--- a/shard/key.go
+++ b/shard/key.go
@@ -35,10 +35,8 @@ func (k Key) String() string {
 	return k.str
 }
 
-//
 // We need a custom JSON marshaller and unmarshaller because str is a
 // private field
-//
 func (k Key) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.str)
 }

--- a/shard_state.go
+++ b/shard_state.go
@@ -43,7 +43,7 @@ func (ss ShardState) String() string {
 		ShardStateErrored:      "ShardStateErrored",
 		ShardStateUnknown:      "ShardStateUnknown",
 	}
-	if ss < 0 || int(ss) >= len(strs) {
+	if int(ss) >= len(strs) {
 		// safety comes first.
 		return "__undefined__"
 	}


### PR DESCRIPTION
Since I need to work on a proposal for a change here (based on discussion @ https://github.com/filecoin-project/boost/pull/715) I thought I'd get familiar with the codebase by attempting a conversion to unified-ci. Maybe there are objections to doing this here though?

Still needs registering in protocol/.github so we get automatic syncs.

Main changes:

* Tests with 1.18 and 1.19 across Linux, macOS and Windows
* Bumps go.mod to 1.18
* Remove CircleCI config
* Remove use of ioutil
* Fix staticcheck errors - mainly just missing `err` checks in tests but it also found an interesting one in registry_test.go where a URL is modified with a noop, I'm not sure it's changed any test results though!

The most interesting bit is trying to get Windows compatibility. In the end I skipped a few of the tests but the main problem seems like a real issue worth fixing at some point—there's no way to properly clean up resources on a Dagstore `Close`. It's very easy to have open file handles and Windows is a bit more strict about removing directories (temp for the tests) when there's open file handles. In particular, the mounts, as they go through `Upgrader`, have the `.completed` file left open in many cases and there's no easy way to get it closed before end of test. Ideally a Dagstore `Close` would handle this but it's not straightforward enough for me to wire all that up in this PR. The Context cancellation test presents a whole other set of issues around resource cleanup, you have open file handles stuck in the channel queue system that just gets dropped on the floor when the context is cancelled. We probably need to track active mounts internally and close them out properly at the end and _also_ figure out how to wire the context through the necessary paths to also close them out on cancellation, although I'm not sure about that because contexts are handled inconsistently through the various API calls so it might be a challenge.