### PR TITLE
Fix: add on-disk deletion of shards

### DIFF
--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -302,7 +302,9 @@ func (d *DAGStore) control() {
 
 			// Delete the entry directly from the datastore as persist does not implement deletion
 			// Persist should not make any changes for the control_loop runs for deletion
-			err = d.store.Delete(d.ctx, datastore.NewKey(s.key.String()))
+			if err := d.store.Delete(d.ctx, datastore.NewKey(s.key.String())); err != nil {
+				log.Errorw("DestroyShard: failed to delete shard from database", "shard", s.key, "error", err)
+			}
 			d.lk.Unlock()
 			res := &ShardResult{Key: s.key, Error: err}
 			d.dispatchResult(res, tsk.waiter)

--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -3,6 +3,8 @@ package dagstore
 import (
 	"context"
 	"fmt"
+
+	"github.com/ipfs/go-datastore"
 )
 
 type OpType int
@@ -297,6 +299,11 @@ func (d *DAGStore) control() {
 
 			d.lk.Lock()
 			delete(d.shards, s.key)
+
+			// Delete the entry directly from the datastore as persis does not implement deletion
+			// Implementing delete in persist will require a new state for deletion and relative action
+			// Persist should not make any changes for the control_loop runs for deletion
+			d.store.Delete(d.ctx, datastore.NewKey(s.key.String()))
 			d.lk.Unlock()
 			res := &ShardResult{Key: s.key, Error: nil}
 			d.dispatchResult(res, tsk.waiter)

--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -313,9 +313,9 @@ func (d *DAGStore) control() {
 
 		}
 
-		// persist the current shard state. Skip if key not found(destroyShard). Otherwise, it
+		// persist the current shard state. Skip if op is OpShardDestroy. Otherwise, it
 		// re-registers the shard
-		if _, ok := d.shards[s.key]; ok {
+		if tsk.op != OpShardDestroy {
 			if err := s.persist(d.ctx, d.config.Datastore); err != nil { // TODO maybe fail shard?
 				log.Warnw("failed to persist shard", "shard", s.key, "error", err)
 			}

--- a/dagstore_control.go
+++ b/dagstore_control.go
@@ -302,9 +302,6 @@ func (d *DAGStore) control() {
 
 			// Delete the entry directly from the datastore as persist does not implement deletion
 			// Persist should not make any changes for the control_loop runs for deletion
-			if err := d.store.Delete(d.ctx, datastore.NewKey(s.key.String())); err != nil {
-				log.Errorw("DestroyShard: failed to delete shard from database", "shard", s.key, "error", err)
-			}
 			d.lk.Unlock()
 			res := &ShardResult{Key: s.key, Error: err}
 			d.dispatchResult(res, tsk.waiter)
@@ -317,7 +314,11 @@ func (d *DAGStore) control() {
 
 		// persist the current shard state. Skip if op is OpShardDestroy. Otherwise, it
 		// re-registers the shard
-		if tsk.op != OpShardDestroy {
+		if tsk.op == OpShardDestroy {
+			if err := d.store.Delete(d.ctx, datastore.NewKey(s.key.String())); err != nil {
+				log.Errorw("DestroyShard: failed to delete shard from database", "shard", s.key, "error", err)
+			}
+		} else {
 			if err := s.persist(d.ctx, d.config.Datastore); err != nil { // TODO maybe fail shard?
 				log.Warnw("failed to persist shard", "shard", s.key, "error", err)
 			}


### PR DESCRIPTION
Currently, dagstore implementation only deletes the shard from in-memory map of keys. When dagstore is restarted, the shard comes back from disk.