### PR TITLE
fix: `FileMount` should use url `Path` instead of `Host`

### DIFF
--- a/mount/file.go
+++ b/mount/file.go
@@ -45,7 +45,7 @@ func (f *FileMount) Serialize() *url.URL {
 
 func (f *FileMount) Deserialize(u *url.URL) error {
 	if u.Path == "" {
-		return fmt.Errorf("invalid host")
+		return fmt.Errorf("invalid path")
 	}
 	f.Path = u.Path
 	return nil

--- a/mount/file.go
+++ b/mount/file.go
@@ -39,15 +39,15 @@ func (f *FileMount) Stat(_ context.Context) (Stat, error) {
 
 func (f *FileMount) Serialize() *url.URL {
 	return &url.URL{
-		Host: f.Path,
+		Path: f.Path,
 	}
 }
 
 func (f *FileMount) Deserialize(u *url.URL) error {
-	if u.Host == "" {
+	if u.Path == "" {
 		return fmt.Errorf("invalid host")
 	}
-	f.Path = u.Host
+	f.Path = u.Path
 	return nil
 }
 

--- a/mount/file_test.go
+++ b/mount/file_test.go
@@ -36,7 +36,7 @@ func TestFileMount(t *testing.T) {
 	require.EqualValues(t, size, stat.Size)
 
 	// check URL.
-	require.Equal(t, mnt.Path, mnt.Serialize().Host)
+	require.Equal(t, mnt.Path, mnt.Serialize().Path)
 
 	info := mnt.Info()
 	require.True(t, info.AccessSequential && info.AccessSeek && info.AccessRandom) // all flags true


### PR DESCRIPTION
We [encountered a bug](https://github.com/celestiaorg/celestia-node/issues/2031) recently after switching from `FSMount` to `FileMount`.

The root cause of the problem was the usage of the `Host` field of `url.URL` to store the file path. This led to incorrect URL encoding, which caused the application to fail when trying to recover the state of shards. 

Should we add backwards compatibility to the `Deserialize` method so that mounts previously `Serialized()` using `Host` will be loaded correctly?