### PR TITLE
fix: PersistedShard.URL should do QueryUnescape before url.Parse.

### DIFF
--- a/shard_persist.go
+++ b/shard_persist.go
@@ -65,10 +65,20 @@ func (s *Shard) UnmarshalJSON(b []byte) error {
 	}
 
 	// restore mount.
-	u, err := url.Parse(ps.URL)
+	// URL should do QueryUnescape first.
+	urlStr, err := url.QueryUnescape(ps.URL)
+	if err != nil {
+		return fmt.Errorf("failed to query unescape URL : %w", err)
+	}
+	u, err := url.Parse(urlStr)
 	if err != nil {
 		return fmt.Errorf("failed to parse mount URL: %w", err)
 	}
+
+	if u.Host == "" {
+		u.Host = u.Path
+	}
+
 	mnt, err := s.d.mounts.Instantiate(u)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate mount from URL: %w", err)


### PR DESCRIPTION
In my dev environment, PersistedShard.URL contains some escape characters, like '%2F'.  The whole URL is `file://%2Fhome%2Fricktian%2Fworkspace%2Flotus_dev%2Fcar%2Fbafk2bzaceddnvrk2uexrfib7yerhd754hw3ed2tfyvemkrpzflbyf2sbioswq.baga6ea4seaqbhygsit3b742jhtny3sjlznpjaevquj3unc4iugno6735z35hmny.car`, And this parse directory will cause error as follow: 
`2023-04-17T15:52:15.006+0800    WARN    dagstore        dagstore@v0.7.0/dagstore.go:572 failed to recover state of shard /baga6ea4seaqbhygsit3b742jhtny3sjlznpjaevquj3unc4iugno6735z35hmny: failed to parse mount URL: parse "file://%2Fhome%2Fricktian%2Fworkspace%2Flotus_dev%2Fcar%2Fbafk2bzaceddnvrk2uexrfib7yerhd754hw3ed2tfyvemkrpzflbyf2sbioswq.baga6ea4seaqbhygsit3b742jhtny3sjlznpjaevquj3unc4iugno6735z35hmny.car": invalid URL escape "%2F"; skipping`

So PersistedShard.URL should be QueryUnescape before Parse.